### PR TITLE
Fix typo sepctral_test -> spectral_test

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -58,7 +58,7 @@ class Main(Frame):
             2:rt.run_test,
             3:rt.longest_one_block_test,
             4:mt.binary_matrix_rank_text,
-            5:st.sepctral_test,
+            5:st.spectral_test,
             6:tm.non_overlapping_test,
             7:tm.overlapping_patterns,
             8:ut.statistical_test,

--- a/OLD_Main.py
+++ b/OLD_Main.py
@@ -50,7 +50,7 @@ class Main(Frame):
             2:rt.run_test,
             3:rt.longest_one_block_test,
             4:mt.binary_matrix_rank_text,
-            5:st.sepctral_test,
+            5:st.spectral_test,
             6:tm.non_overlapping_test,
             7:tm.overlapping_patterns,
             8:ut.statistical_test,

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ print('2.02. Block Frequency Test:\t\t\t\t\t\t\t', FrequencyTest.block_frequency
 print('2.03. Run Test:\t\t\t\t\t\t\t\t\t\t', RunTest.run_test(binary_data[:1000000]))
 print('2.04. Run Test (Longest Run of Ones): \t\t\t\t', RunTest.longest_one_block_test(binary_data[:1000000]))
 print('2.05. Binary Matrix Rank Test:\t\t\t\t\t\t', Matrix.binary_matrix_rank_text(binary_data[:1000000]))
-print('2.06. Discrete Fourier Transform (Spectral) Test:\t', SpectralTest.sepctral_test(binary_data[:1000000]))
+print('2.06. Discrete Fourier Transform (Spectral) Test:\t', SpectralTest.spectral_test(binary_data[:1000000]))
 print('2.07. Non-overlapping Template Matching Test:\t\t', TemplateMatching.non_overlapping_test(binary_data[:1000000], '000000001'))
 print('2.08. Overlappong Template Matching Test: \t\t\t', TemplateMatching.overlapping_patterns(binary_data[:1000000]))
 print('2.09. Universal Statistical Test:\t\t\t\t\t', Universal.statistical_test(binary_data[:1000000]))

--- a/Spectral.py
+++ b/Spectral.py
@@ -9,7 +9,7 @@ from scipy.special import erfc as erfc
 class SpectralTest:
 
     @staticmethod
-    def sepctral_test(binary_data:str, verbose=False):
+    def spectral_test(binary_data:str, verbose=False):
         """
         Note that this description is taken from the NIST documentation [1]
         [1] http://csrc.nist.gov/publications/nistpubs/800-22-rev1a/SP800-22rev1a.pdf

--- a/test_e.py
+++ b/test_e.py
@@ -27,7 +27,7 @@ print('2.02. Block Frequency Test:\t\t\t\t\t\t\t', FrequencyTest.block_frequency
 print('2.03. Run Test:\t\t\t\t\t\t\t\t\t\t', RunTest.run_test(binary_data[:1000000]))
 print('2.04. Run Test (Longest Run of Ones): \t\t\t\t', RunTest.longest_one_block_test(binary_data[:1000000]))
 print('2.05. Binary Matrix Rank Test:\t\t\t\t\t\t', Matrix.binary_matrix_rank_text(binary_data[:1000000]))
-print('2.06. Discrete Fourier Transform (Spectral) Test:\t', SpectralTest.sepctral_test(binary_data[:1000000]))
+print('2.06. Discrete Fourier Transform (Spectral) Test:\t', SpectralTest.spectral_test(binary_data[:1000000]))
 print('2.07. Non-overlapping Template Matching Test:\t\t', TemplateMatching.non_overlapping_test(binary_data[:1000000], '000000001'))
 print('2.08. Overlappong Template Matching Test: \t\t\t', TemplateMatching.overlapping_patterns(binary_data[:1000000]))
 print('2.09. Universal Statistical Test:\t\t\t\t\t', Universal.statistical_test(binary_data[:1000000]))

--- a/test_pi.py
+++ b/test_pi.py
@@ -27,7 +27,7 @@ print('2.2. Block Frequency Test:\t\t\t\t\t\t\t\t', FrequencyTest.block_frequenc
 print('2.3. Run Test:\t\t\t\t\t\t\t\t\t\t\t', RunTest.run_test(binary_data[:1000000]))
 print('2.4. Run Test (Longest Run of Ones): \t\t\t\t\t', RunTest.longest_one_block_test(binary_data[:1000000]))
 print('2.5. Binary Matrix Rank Test:\t\t\t\t\t\t\t', Matrix.binary_matrix_rank_text(binary_data[:1000000]))
-print('2.6. Discrete Fourier Transform (Spectral) Test: \t\t', SpectralTest.sepctral_test(binary_data[:1000000]))
+print('2.6. Discrete Fourier Transform (Spectral) Test: \t\t', SpectralTest.spectral_test(binary_data[:1000000]))
 print('2.7. Non-overlapping Template Matching Test:\t\t\t', TemplateMatching.non_overlapping_test(binary_data[:1000000], '000000001'))
 print('2.8. Overlappong Template Matching Test: \t\t\t\t', TemplateMatching.overlapping_patterns(binary_data[:1000000]))
 print('2.9. Universal Statistical Test:\t\t\t\t\t\t', Universal.statistical_test(binary_data[:1000000]))

--- a/test_sqrt2.py
+++ b/test_sqrt2.py
@@ -27,7 +27,7 @@ print('2.2. Block Frequency Test:\t\t\t\t\t\t\t\t', FrequencyTest.block_frequenc
 print('2.3. Run Test:\t\t\t\t\t\t\t\t\t\t\t', RunTest.run_test(binary_data[:1000000]))
 print('2.4. Run Test (Longest Run of Ones): \t\t\t\t\t', RunTest.longest_one_block_test(binary_data[:1000000]))
 print('2.5. Binary Matrix Rank Test:\t\t\t\t\t\t\t', Matrix.binary_matrix_rank_text(binary_data[:1000000]))
-print('2.6. Discrete Fourier Transform (Spectral) Test: \t\t', SpectralTest.sepctral_test(binary_data[:1000000]))
+print('2.6. Discrete Fourier Transform (Spectral) Test: \t\t', SpectralTest.spectral_test(binary_data[:1000000]))
 print('2.7. Non-overlapping Template Matching Test:\t\t\t', TemplateMatching.non_overlapping_test(binary_data[:1000000], '000000001'))
 print('2.8. Overlappong Template Matching Test: \t\t\t\t', TemplateMatching.overlapping_patterns(binary_data[:1000000]))
 print('2.9. Universal Statistical Test:\t\t\t\t\t\t', Universal.statistical_test(binary_data[:1000000]))

--- a/test_sqrt3.py
+++ b/test_sqrt3.py
@@ -27,7 +27,7 @@ print('2.2. Block Frequency Test:\t\t\t\t\t\t\t\t', FrequencyTest.block_frequenc
 print('2.3. Run Test:\t\t\t\t\t\t\t\t\t\t\t', RunTest.run_test(binary_data[:1000000]))
 print('2.4. Run Test (Longest Run of Ones): \t\t\t\t\t', RunTest.longest_one_block_test(binary_data[:1000000]))
 print('2.5. Binary Matrix Rank Test:\t\t\t\t\t\t\t', Matrix.binary_matrix_rank_text(binary_data[:1000000]))
-print('2.6. Discrete Fourier Transform (Spectral) Test: \t\t', SpectralTest.sepctral_test(binary_data[:1000000]))
+print('2.6. Discrete Fourier Transform (Spectral) Test: \t\t', SpectralTest.spectral_test(binary_data[:1000000]))
 print('2.7. Non-overlapping Template Matching Test:\t\t\t', TemplateMatching.non_overlapping_test(binary_data[:1000000], '000000001'))
 print('2.8. Overlappong Template Matching Test: \t\t\t\t', TemplateMatching.overlapping_patterns(binary_data[:1000000]))
 print('2.9. Universal Statistical Test:\t\t\t\t\t\t', Universal.statistical_test(binary_data[:1000000]))

--- a/test_url_01.py
+++ b/test_url_01.py
@@ -28,7 +28,7 @@ test_function = {
             2:rt.run_test,
             3:rt.longest_one_block_test,
             4:mt.binary_matrix_rank_text,
-            5:st.sepctral_test,
+            5:st.spectral_test,
             6:tm.non_overlapping_test,
             7:tm.overlapping_patterns,
             8:ut.statistical_test,


### PR DESCRIPTION
Saw a typo I wanted to fix. Used search and replace to get all instances.