### PR TITLE
scipy.zeros is deprecated and was removed in v.1.20.0rc1

### DIFF
--- a/RunTest.py
+++ b/RunTest.py
@@ -3,7 +3,7 @@ from math import floor as floor
 from math import sqrt as sqrt
 from scipy.special import erfc as erfc
 from scipy.special import gammaincc as gammaincc
-from scipy import zeros as zeros
+from numpy import zeros
 
 class RunTest:
 


### PR DESCRIPTION
 Replaced by numpy.zeros as suggested by scipy. Fixed #21 